### PR TITLE
Add <title> to index.html

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,5 +1,6 @@
 <html>
 	<head>
+		<title>clang-format configurator</title> 
 		<script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>


### PR DESCRIPTION
This makes browsers display "clang-format configurator" as the title instead of the page URL.
